### PR TITLE
refactor: extract common layout into reusable component

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="/src/assets/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>KU Connect</title>
   </head>

--- a/src/assets/favicon.svg
+++ b/src/assets/favicon.svg
@@ -1,0 +1,9 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Transformed by: SVG Repo Mixer Tools -->
+<svg fill="#34d399" width="800px" height="800px" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" data-name="Layer 1">
+<g id="SVGRepo_bgCarrier" stroke-width="0"/>
+<g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"/>
+<g id="SVGRepo_iconCarrier">
+<path d="M21.49,10.19l-1-.55h0l-9-5-.11,0a1.06,1.06,0,0,0-.19-.06l-.19,0-.18,0a1.17,1.17,0,0,0-.2.06l-.11,0-9,5a1,1,0,0,0,0,1.74L4,12.76V17.5a3,3,0,0,0,3,3h8a3,3,0,0,0,3-3V12.76l2-1.12V14.5a1,1,0,0,0,2,0V11.06A1,1,0,0,0,21.49,10.19ZM16,17.5a1,1,0,0,1-1,1H7a1,1,0,0,1-1-1V13.87l4.51,2.5.15.06.09,0a1,1,0,0,0,.25,0h0a1,1,0,0,0,.25,0l.09,0a.47.47,0,0,0,.15-.06L16,13.87Zm-5-3.14L4.06,10.5,11,6.64l6.94,3.86Z"/>
+</g>
+</svg>

--- a/src/components/app-sidebar.jsx
+++ b/src/components/app-sidebar.jsx
@@ -159,8 +159,12 @@ export function AppSidebar({ ...props }) {
             <SidebarMenuButton
               asChild
               className="data-[slot=sidebar-menu-button]:!p-1.5">
-              <a href="#">
-                <IconInnerShadowTop className="!size-5" />
+              <a href="/dashboard">
+                <img
+                  src="/src/assets/favicon.svg"
+                  alt="logo"
+                  className="!size-5"
+                />
                 <span className="text-base font-semibold">KU Connect</span>
               </a>
             </SidebarMenuButton>

--- a/src/components/layout.jsx
+++ b/src/components/layout.jsx
@@ -1,0 +1,19 @@
+import { AppSidebar } from "@/components/app-sidebar";
+import { SiteHeader } from "@/components/site-header";
+import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
+
+export default function AppLayout({ children }) {
+  return (
+    <SidebarProvider
+      style={{
+        "--sidebar-width": "calc(var(--spacing) * 72)",
+        "--header-height": "calc(var(--spacing) * 12)",
+      }}>
+      <AppSidebar variant="inset" />
+      <SidebarInset>
+        <SiteHeader />
+        {children}
+      </SidebarInset>
+    </SidebarProvider>
+  );
+}

--- a/src/pages/askSeniors.jsx
+++ b/src/pages/askSeniors.jsx
@@ -1,21 +1,11 @@
-import { AppSidebar } from "@/components/app-sidebar";
-import { SiteHeader } from "@/components/site-header";
-import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
+import AppLayout from "@/components/layout";
 
 export default function AskSeniorsPage() {
   return (
-    <SidebarProvider
-      style={{
-        "--sidebar-width": "calc(var(--spacing) * 72)",
-        "--header-height": "calc(var(--spacing) * 12)",
-      }}>
-      <AppSidebar variant="inset" />
-      <SidebarInset>
-        <SiteHeader />
-        <div className="flex justify-center items-center h-full">
-          <h1>Ask Seniors</h1>
-        </div>
-      </SidebarInset>
-    </SidebarProvider>
+    <AppLayout>
+      <div className="flex justify-center items-center h-full">
+        <h1>Ask Seniors</h1>
+      </div>
+    </AppLayout>
   );
 }

--- a/src/pages/dashboard.jsx
+++ b/src/pages/dashboard.jsx
@@ -1,34 +1,24 @@
-import { AppSidebar } from "@/components/app-sidebar";
-import { ChartAreaInteractive } from "@/components/chart-area-interactive";
+import AppLayout from "@/components/layout";
 import { DataTable } from "@/components/data-table";
 import { SectionCards } from "@/components/section-cards";
-import { SiteHeader } from "@/components/site-header";
-import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
+import { ChartAreaInteractive } from "@/components/chart-area-interactive";
 
 import data from "@/app/dashboard/data.json";
 
 export default function Dashboard() {
   return (
-    <SidebarProvider
-      style={{
-        "--sidebar-width": "calc(var(--spacing) * 72)",
-        "--header-height": "calc(var(--spacing) * 12)",
-      }}>
-      <AppSidebar variant="inset" />
-      <SidebarInset>
-        <SiteHeader />
-        <div className="flex flex-1 flex-col">
-          <div className="@container/main flex flex-1 flex-col gap-2">
-            <div className="flex flex-col gap-4 py-4 md:gap-6 md:py-6">
-              <SectionCards />
-              <div className="px-4 lg:px-6">
-                <ChartAreaInteractive />
-              </div>
-              <DataTable data={data} />
+    <AppLayout>
+      <div className="flex flex-1 flex-col">
+        <div className="@container/main flex flex-1 flex-col gap-2">
+          <div className="flex flex-col gap-4 py-4 md:gap-6 md:py-6">
+            <SectionCards />
+            <div className="px-4 lg:px-6">
+              <ChartAreaInteractive />
             </div>
+            <DataTable data={data} />
           </div>
         </div>
-      </SidebarInset>
-    </SidebarProvider>
+      </div>
+    </AppLayout>
   );
 }

--- a/src/pages/gpaCalculator.jsx
+++ b/src/pages/gpaCalculator.jsx
@@ -1,21 +1,11 @@
-import { AppSidebar } from "@/components/app-sidebar";
-import { SiteHeader } from "@/components/site-header";
-import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
+import AppLayout from "@/components/layout";
 
 export default function GpaCalculatorPage() {
   return (
-    <SidebarProvider
-      style={{
-        "--sidebar-width": "calc(var(--spacing) * 72)",
-        "--header-height": "calc(var(--spacing) * 12)",
-      }}>
-      <AppSidebar variant="inset" />
-      <SidebarInset>
-        <SiteHeader />
-        <div className="flex justify-center items-center h-full">
-          <h1>GPA Calculator</h1>
-        </div>
-      </SidebarInset>
-    </SidebarProvider>
+    <AppLayout>
+      <div className="flex justify-center items-center h-full">
+        <h1>GPA Calculator</h1>
+      </div>
+    </AppLayout>
   );
 }

--- a/src/pages/resources.jsx
+++ b/src/pages/resources.jsx
@@ -1,21 +1,11 @@
-import { AppSidebar } from "@/components/app-sidebar";
-import { SiteHeader } from "@/components/site-header";
-import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
+import AppLayout from "@/components/layout";
 
 export default function ResourcesPage() {
   return (
-    <SidebarProvider
-      style={{
-        "--sidebar-width": "calc(var(--spacing) * 72)",
-        "--header-height": "calc(var(--spacing) * 12)",
-      }}>
-      <AppSidebar variant="inset" />
-      <SidebarInset>
-        <SiteHeader />
-        <div className="flex justify-center items-center h-full">
-          <h1>Resources Page</h1>
-        </div>
-      </SidebarInset>
-    </SidebarProvider>
+    <AppLayout>
+      <div className="flex justify-center items-center h-full">
+        <h1>Resources Page</h1>
+      </div>
+    </AppLayout>
   );
 }

--- a/src/pages/support.jsx
+++ b/src/pages/support.jsx
@@ -1,21 +1,11 @@
-import { AppSidebar } from "@/components/app-sidebar";
-import { SiteHeader } from "@/components/site-header";
-import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
+import AppLayout from "@/components/layout";
 
 export default function SupportPage() {
   return (
-    <SidebarProvider
-      style={{
-        "--sidebar-width": "calc(var(--spacing) * 72)",
-        "--header-height": "calc(var(--spacing) * 12)",
-      }}>
-      <AppSidebar variant="inset" />
-      <SidebarInset>
-        <SiteHeader />
-        <div className="flex justify-center items-center h-full">
-          <h1>Support</h1>
-        </div>
-      </SidebarInset>
-    </SidebarProvider>
+    <AppLayout>
+      <div className="flex justify-center items-center h-full">
+        <h1>Support</h1>
+      </div>
+    </AppLayout>
   );
 }


### PR DESCRIPTION
Created a reusable Layout component to wrap pages with SidebarProvider, AppSidebar, SidebarInset, and SiteHeader, reducing code duplication across all pages.