### PR TITLE
feat(auth): enforce onboarding completion in ProtectedRoute

### DIFF
--- a/src/components/protected-route.jsx
+++ b/src/components/protected-route.jsx
@@ -1,16 +1,29 @@
-import { Navigate } from "react-router-dom";
-import useStore from "../store";
+import useStore from "@/store";
+import { Navigate, useLocation } from "react-router-dom";
 
 function ProtectedRoute({ children }) {
+  const location = useLocation();
+  const { completed } = useStore((state) => state.onboarding);
   const { isAuthenticated, rehydrated } = useStore((state) => state.auth);
 
-  // If still rehydrating, show nothing (or a loader/spinner)
+  // If still rehydrating, show loader
   if (!rehydrated) {
     return <div>Loading...</div>;
   }
 
+  // If not logged in → redirect to login
   if (!isAuthenticated) {
     return <Navigate to="/login" replace />;
+  }
+
+  // If logged in but onboarding not completed → redirect to onboarding
+  if (!completed && location.pathname !== "/onboarding") {
+    return <Navigate to="/onboarding" replace />;
+  }
+
+  // If onboarding is already completed but user tries to access onboarding page → redirect to dashboard
+  if (completed && location.pathname === "/onboarding") {
+    return <Navigate to="/dashboard" replace />;
   }
 
   return children;


### PR DESCRIPTION
- Extended ProtectedRoute to check `onboarding.completed` from store
- Redirect users without completed onboarding to `/onboarding`
- Prevent users with completed onboarding from revisiting `/onboarding`
- Ensures consistent flow: new users must complete onboarding before accessing dashboard or other protected routes