### PR TITLE
feat(store): persist onboarding and setup rehydrate logic

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,18 +5,20 @@ import LoginPage from "./pages/login";
 import SignupPage from "./pages/signup";
 import NotFound from "./pages/notFound";
 import Dashboard from "./pages/dashboard";
+import Onboarding from "./pages/onBoarding";
 import AskSeniorsPage from "./pages/askSeniors";
 import ProtectedRoute from "./components/protected-route";
 import CourseView from "./pages/gpa-calculator/course-view";
 import SemesterView from "./pages/gpa-calculator/semester-view";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
-import Onboarding from "./pages/onBoarding";
 
 function App() {
   const rehydrateAuth = useStore((state) => state.rehydrateAuth);
+  const rehydrateOnboarding = useStore((state) => state.rehydrateOnboarding);
 
   useEffect(() => {
     rehydrateAuth();
+    rehydrateOnboarding();
   }, []);
 
   return (

--- a/src/components/protected-route.jsx
+++ b/src/components/protected-route.jsx
@@ -22,7 +22,11 @@ function ProtectedRoute({ children }) {
   }
 
   // If onboarding is already completed but user tries to access onboarding page → redirect to dashboard
-  if (completed && location.pathname === "/onboarding") {
+  if (
+    completed &&
+    (location.pathname === "/onboarding" ||
+      location.pathname === "/onboarding/")
+  ) {
     return <Navigate to="/dashboard" replace />;
   }
 

--- a/src/store/slices/onboarding.jsx
+++ b/src/store/slices/onboarding.jsx
@@ -3,6 +3,7 @@ export const createOnboardingSlice = (set) => ({
     department: "",
     semester: "",
     completed: false,
+    rehydrated: false,
   },
 
   setDepartment: (department) =>
@@ -12,6 +13,7 @@ export const createOnboardingSlice = (set) => ({
         department,
       },
     })),
+
   setSemester: (semester) =>
     set((state) => ({
       onboarding: {
@@ -19,19 +21,44 @@ export const createOnboardingSlice = (set) => ({
         semester,
       },
     })),
+
   completeOnboarding: () =>
-    set((state) => ({
-      onboarding: {
+    set((state) => {
+      const updated = {
         ...state.onboarding,
         completed: true,
-      },
-    })),
-  resetOnboarding: () =>
-    set(() => ({
+      };
+      localStorage.setItem("onboarding", JSON.stringify(updated));
+      return { onboarding: updated };
+    }),
+
+  resetOnboarding: () => {
+    localStorage.removeItem("onboarding");
+    return set(() => ({
       onboarding: {
         department: "",
         semester: "",
         completed: false,
+        rehydrated: true,
       },
-    })),
+    }));
+  },
+
+  rehydrateOnboarding: () => {
+    const raw = localStorage.getItem("onboarding");
+    if (raw) {
+      set({
+        onboarding: { ...JSON.parse(raw), rehydrated: true },
+      });
+    } else {
+      set({
+        onboarding: {
+          department: "",
+          semester: "",
+          completed: false,
+          rehydrated: true,
+        },
+      });
+    }
+  },
 });


### PR DESCRIPTION
- Refactored store to persist onboarding.
- Added logic to call rehydrate in App.jsx.
- Updated protected route to make sure a user can't access onboarding page after completing the process once.