### PR TITLE
refactor(auth): remove obsolete local onboarding setters

### DIFF
--- a/src/apis/auth.jsx
+++ b/src/apis/auth.jsx
@@ -9,3 +9,8 @@ export const login = async (data) => {
   const res = await api.post("/auth/login", data);
   return res.data;
 };
+
+export const saveOnboarding = async (data) => {
+  const res = await api.post("/auth/onboarding", data);
+  return res.data;
+};

--- a/src/pages/auth/onboarding.jsx
+++ b/src/pages/auth/onboarding.jsx
@@ -28,16 +28,20 @@ export default function Onboarding() {
     },
   });
 
-  const onSubmit = (values) => {
-    const { setDepartment, setSemester, completeOnboarding } =
-      useStore.getState();
+  const onSubmit = async (values) => {
+    const { saveOnboarding } = useStore.getState();
 
-    setDepartment(values.department);
-    setSemester(values.semester);
-    completeOnboarding();
+    try {
+      await saveOnboarding({
+        department: values.department,
+        semester: values.semester,
+        completed: true,
+      });
 
-    console.log("Saved onboarding:", values);
-    navigate("/dashboard");
+      navigate("/dashboard");
+    } catch (err) {
+      console.error("Onboarding error:", err);
+    }
   };
 
   return (

--- a/src/store/slices/auth.jsx
+++ b/src/store/slices/auth.jsx
@@ -92,43 +92,25 @@ const createAuthSlice = (set, get) => ({
     }
   },
 
-  setDepartment: (department) => {
-    const { auth } = get();
-    const updatedUser = { ...auth.user, department };
+  saveOnboarding: async (onboardingData) => {
+    try {
+      const { token, user } = await authApi.saveOnboarding(onboardingData);
 
-    localStorage.setItem("user", JSON.stringify(updatedUser));
-    set({
-      auth: {
-        ...auth,
-        user: updatedUser,
-      },
-    });
-  },
+      localStorage.setItem("token", token);
+      localStorage.setItem("user", JSON.stringify(user));
 
-  setSemester: (semester) => {
-    const { auth } = get();
-    const updatedUser = { ...auth.user, semester };
-
-    localStorage.setItem("user", JSON.stringify(updatedUser));
-    set({
-      auth: {
-        ...auth,
-        user: updatedUser,
-      },
-    });
-  },
-
-  completeOnboarding: () => {
-    const { auth } = get();
-    const updatedUser = { ...auth.user, completed: true };
-
-    localStorage.setItem("user", JSON.stringify(updatedUser));
-    set({
-      auth: {
-        ...auth,
-        user: updatedUser,
-      },
-    });
+      set((state) => ({
+        auth: {
+          ...state.auth,
+          token,
+          user,
+          isAuthenticated: true,
+          rehydrated: true,
+        },
+      }));
+    } catch (err) {
+      throw err.response?.data?.error || "Onboarding failed";
+    }
   },
 });
 


### PR DESCRIPTION
- Deleted setDepartment, setSemester, and completeOnboarding from auth slice
- Onboarding state is now fully handled via saveOnboarding API call
- Simplified slice to avoid redundant local state mutations